### PR TITLE
Close #54

### DIFF
--- a/Apps/Components/CMC/2099 - Interface/Controls/Button/btn.Designer.vb
+++ b/Apps/Components/CMC/2099 - Interface/Controls/Button/btn.Designer.vb
@@ -1,8 +1,8 @@
-﻿<System.Drawing.ToolboxBitmap(GetType(CMCv.btn), "btn.ico")> _
-Partial Class btn
+﻿<System.Drawing.ToolboxBitmap(GetType(CMCv.Btn), "btn.ico")>
+Partial Class Btn
     Inherits System.Windows.Forms.Button
 
-    <System.Diagnostics.DebuggerNonUserCode()> _
+    <System.Diagnostics.DebuggerNonUserCode()>
     Public Sub New(ByVal container As System.ComponentModel.IContainer)
         MyClass.New()
 
@@ -15,7 +15,7 @@ Partial Class btn
 
 
     'Component overrides dispose to clean up the component list.
-    <System.Diagnostics.DebuggerNonUserCode()> _
+    <System.Diagnostics.DebuggerNonUserCode()>
     Protected Overrides Sub Dispose(ByVal disposing As Boolean)
         Try
             If disposing AndAlso components IsNot Nothing Then
@@ -32,7 +32,7 @@ Partial Class btn
     'NOTE: The following procedure is required by the Component Designer
     'It can be modified using the Component Designer.
     'Do not modify it using the code editor.
-    <System.Diagnostics.DebuggerStepThrough()> _
+    <System.Diagnostics.DebuggerStepThrough()>
     Private Sub InitializeComponent()
         components = New System.ComponentModel.Container()
     End Sub

--- a/Apps/Components/CMC/2099 - Interface/Controls/Button/btn.vb
+++ b/Apps/Components/CMC/2099 - Interface/Controls/Button/btn.vb
@@ -1,10 +1,5 @@
-﻿'Imports System
-'Imports System.Drawing
-'Imports System.Windows.Forms
-'Imports System.Windows.Forms.VisualStyles
-Imports System.ComponentModel
+﻿Imports System.ComponentModel
 Imports System.Runtime.Versioning
-
 
 ''' <project>CMCC</project>
 ''' <author>Ardha Gp</author>
@@ -12,7 +7,7 @@ Imports System.Runtime.Versioning
 ''' Custom button
 ''' </summary>
 ''' <remarks></remarks>
-Public Class btn
+Public Class Btn
     Inherits System.Windows.Forms.Button
     Public Event ValidasiBerhasil()
 
@@ -22,11 +17,9 @@ Public Class btn
         Call ActivateLicenses()
         MyBase.FlatStyle = Windows.Forms.FlatStyle.Flat
         MyBase.FlatAppearance.BorderSize = 2
-        'MyBase.BackColor = System.Drawing.Color.Orange
         MyBase.Size = New System.Drawing.Size(100, 40)
         MyBase.Cursor = System.Windows.Forms.Cursors.Hand
         MyBase.Font = globalFontBtn
-        'Me.XOTampilkanBorder = False
         Me.XOTampilkanFocusBorder = False
         Me.XOJenisTombol = ControlCodeBase.enuJenisTombol.Default
         MyBase.DoubleBuffered = True
@@ -34,7 +27,7 @@ Public Class btn
 
     Private _varJenisTombol As ControlCodeBase.enuJenisTombol
     <Category("Text"),
-    Description("Jenis tombol akan mempengaruhi (warna latar, jenis font) tombol")>
+        Description("Jenis tombol akan mempengaruhi (warna latar, jenis font) tombol")>
     Public Property XOJenisTombol() As ControlCodeBase.enuJenisTombol
         Get
             Return _varJenisTombol
@@ -47,7 +40,7 @@ Public Class btn
 
     Private _varValidasiSemuaInput As Boolean
     <Category("Text"),
-    Description("Memvalidasi semua input telah diisi")>
+        Description("Memvalidasi semua input telah diisi")>
     Public Property XOValidasiSemuaInput() As Boolean
         Get
             Return _varValidasiSemuaInput
@@ -59,7 +52,7 @@ Public Class btn
 
     Private _varValidasiSemuaInputTag As String
     <Category("Text"),
-    Description("Teksboks dengan Tag ini yang akan divalidasi")>
+        Description("Teksboks dengan Tag ini yang akan divalidasi")>
     Public Property XOValidasiSemuaInputTag() As String
         Get
             Return _varValidasiSemuaInputTag
@@ -68,30 +61,6 @@ Public Class btn
             _varValidasiSemuaInputTag = value
         End Set
     End Property
-
-    'Private _varStatusTeks As String
-    '<Category("Text"), _
-    'Description("Teks yang ditampilkan pada bilah status")> _
-    'Public Property SLFStatusTeks() As String
-    '    Get
-    '        Return _varStatusTeks
-    '    End Get
-    '    Set(value As String)
-    '        _varStatusTeks = value
-    '    End Set
-    'End Property
-
-    'Private _varStatusTeksKomponen As CMCv.stt
-    '<Category("Text"), _
-    'Description("Tulisan yang tampil di status")> _
-    'Public Property SLFStatusTeksKomponen(Optional ByVal KomponenStatus As CMCv.stt = Nothing) As CMCv.stt
-    '    Get
-    '        Return _varStatusTeksKomponen
-    '    End Get
-    '    Set(value As CMCv.stt)
-    '        _varStatusTeksKomponen = value
-    '    End Set
-    'End Property
 
     ''' <summary>
     ''' Ganti warna tombol.
@@ -140,54 +109,4 @@ Public Class btn
             _varTampilkanFocusBorder = value
         End Set
     End Property
-
-    'Private _varTampilkanBorder As Boolean = False
-    'Public Property SLFTampilkanBorder() As Boolean
-    '    Get
-    '        Return _varTampilkanBorder
-    '    End Get
-    '    Set(value As Boolean)
-    '        _varTampilkanBorder = value
-    '    End Set
-    'End Property
-
-    'Protected Overrides Sub OnPaint(pe As System.Windows.Forms.PaintEventArgs)
-    '    MyBase.OnPaint(pe)
-    '    If SLFTampilkanBorder = True Then
-    '        pe.Graphics.DrawRectangle(New System.Drawing.Pen(BackColor, 5), ClientRectangle)
-    '    Else
-    '        pe.Graphics.DrawRectangle(New System.Drawing.Pen(BackColor, 0), ClientRectangle)
-    '    End If
-    'End Sub
-
-
-    'Private _varRenderer As VisualStyleRenderer
-    'Private _varButtonBgColor As System.Drawing.Color
-    'Protected Overrides Sub OnPaint(pevent As System.Windows.Forms.PaintEventArgs)
-    '    MyBase.OnPaint(pevent)
-    'If Me.Focused AndAlso Application.RenderWithVisualStyles AndAlso Me.FlatStyle = FlatStyle.Standard Then
-    '    If _varRenderer Is Nothing Then
-    '        Dim elem As VisualStyleElement
-    '        elem = VisualStyleElement.Button.PushButton.Normal
-    '        _varRenderer = New VisualStyleRenderer(elem.ClassName, elem.Part, Int(PushButtonState.Normal))
-    '        Dim rc As Rectangle
-    '        rc = _varRenderer.GetBackgroundContentRectangle(pevent.Graphics, New Rectangle(0, 0, Me.Width, Me.Height))
-    '        rc.Height -= 1
-    '        rc.Width -= 1
-    '        _varButtonBgColor = MyBase.BackColor
-    '        Using p As New Pen(_varButtonBgColor)
-    '            pevent.Graphics.DrawRectangle(p, rc)
-    '        End Using
-
-    '    End If
-    'End If
-    'End Sub
-
-    'Public Overrides Sub NotifyDefault(value As Boolean)
-    '    MyBase.NotifyDefault(False)
-    'End Sub
-
-    'Private Sub btn_GotFocus(sender As Object, e As EventArgs) Handles Me.GotFocus
-    '    _varStatusTeksKomponen.Text = _varStatusTeks
-    'End Sub
 End Class

--- a/Apps/Components/CMC/2099 - Interface/Controls/CheckBox/chk.Designer.vb
+++ b/Apps/Components/CMC/2099 - Interface/Controls/CheckBox/chk.Designer.vb
@@ -1,8 +1,8 @@
-﻿<System.Drawing.ToolboxBitmap(GetType(CMCv.chk), "chk.ico")> _
-Partial Class chk
+﻿<System.Drawing.ToolboxBitmap(GetType(CMCv.Chk), "chk.ico")>
+Partial Class Chk
     Inherits System.Windows.Forms.CheckBox
 
-    <System.Diagnostics.DebuggerNonUserCode()> _
+    <System.Diagnostics.DebuggerNonUserCode()>
     Public Sub New(ByVal container As System.ComponentModel.IContainer)
         MyClass.New()
 
@@ -14,7 +14,7 @@ Partial Class chk
     End Sub
 
     'Component overrides dispose to clean up the component list.
-    <System.Diagnostics.DebuggerNonUserCode()> _
+    <System.Diagnostics.DebuggerNonUserCode()>
     Protected Overrides Sub Dispose(ByVal disposing As Boolean)
         Try
             If disposing AndAlso components IsNot Nothing Then
@@ -31,7 +31,7 @@ Partial Class chk
     'NOTE: The following procedure is required by the Component Designer
     'It can be modified using the Component Designer.
     'Do not modify it using the code editor.
-    <System.Diagnostics.DebuggerStepThrough()> _
+    <System.Diagnostics.DebuggerStepThrough()>
     Private Sub InitializeComponent()
         components = New System.ComponentModel.Container()
     End Sub

--- a/Apps/Components/CMC/2099 - Interface/Controls/CheckBox/chk.vb
+++ b/Apps/Components/CMC/2099 - Interface/Controls/CheckBox/chk.vb
@@ -5,7 +5,7 @@
 ''' <summary>
 ''' Custom checkbox
 ''' </summary>
-Public Class chk
+Public Class Chk
     Inherits System.Windows.Forms.CheckBox
 
     <SupportedOSPlatform("windows")>

--- a/Apps/Components/CMC/2099 - Interface/Controls/ComboBox/cbo.Designer.vb
+++ b/Apps/Components/CMC/2099 - Interface/Controls/ComboBox/cbo.Designer.vb
@@ -1,8 +1,8 @@
-﻿<System.Drawing.ToolboxBitmap(GetType(CMCv.cbo), "cbo.ico")> _
-Partial Class cbo
+﻿<System.Drawing.ToolboxBitmap(GetType(CMCv.Cbo), "cbo.ico")>
+Partial Class Cbo
     Inherits System.Windows.Forms.ComboBox
 
-    <System.Diagnostics.DebuggerNonUserCode()> _
+    <System.Diagnostics.DebuggerNonUserCode()>
     Public Sub New(ByVal container As System.ComponentModel.IContainer)
         MyClass.New()
 
@@ -13,7 +13,7 @@ Partial Class cbo
     End Sub
 
     'Component overrides dispose to clean up the component list.
-    <System.Diagnostics.DebuggerNonUserCode()> _
+    <System.Diagnostics.DebuggerNonUserCode()>
     Protected Overrides Sub Dispose(ByVal disposing As Boolean)
         Try
             If disposing AndAlso components IsNot Nothing Then
@@ -30,7 +30,7 @@ Partial Class cbo
     'NOTE: The following procedure is required by the Component Designer
     'It can be modified using the Component Designer.
     'Do not modify it using the code editor.
-    <System.Diagnostics.DebuggerStepThrough()> _
+    <System.Diagnostics.DebuggerStepThrough()>
     Private Sub InitializeComponent()
         components = New System.ComponentModel.Container()
     End Sub

--- a/Apps/Components/CMC/2099 - Interface/Controls/ComboBox/cbo.vb
+++ b/Apps/Components/CMC/2099 - Interface/Controls/ComboBox/cbo.vb
@@ -5,7 +5,7 @@
 ''' <summary>
 ''' Custom combobox
 ''' </summary>
-Public Class cbo
+Public Class Cbo
     Inherits System.Windows.Forms.ComboBox
 
     <SupportedOSPlatform("windows")>

--- a/Apps/Components/CMC/2099 - Interface/Controls/Context Menu/csmnu.Designer.vb
+++ b/Apps/Components/CMC/2099 - Interface/Controls/Context Menu/csmnu.Designer.vb
@@ -1,7 +1,7 @@
-﻿Partial Class csmnu
+﻿Partial Class Csmnu
     Inherits System.Windows.Forms.ContextMenuStrip
 
-    <System.Diagnostics.DebuggerNonUserCode()> _
+    <System.Diagnostics.DebuggerNonUserCode()>
     Public Sub New(ByVal container As System.ComponentModel.IContainer)
         MyClass.New()
 
@@ -13,7 +13,7 @@
     End Sub
 
     'Component overrides dispose to clean up the component list.
-    <System.Diagnostics.DebuggerNonUserCode()> _
+    <System.Diagnostics.DebuggerNonUserCode()>
     Protected Overrides Sub Dispose(ByVal disposing As Boolean)
         Try
             If disposing AndAlso components IsNot Nothing Then
@@ -30,7 +30,7 @@
     'NOTE: The following procedure is required by the Component Designer
     'It can be modified using the Component Designer.
     'Do not modify it using the code editor.
-    <System.Diagnostics.DebuggerStepThrough()> _
+    <System.Diagnostics.DebuggerStepThrough()>
     Private Sub InitializeComponent()
         components = New System.ComponentModel.Container()
     End Sub

--- a/Apps/Components/CMC/2099 - Interface/Controls/Context Menu/csmnu.vb
+++ b/Apps/Components/CMC/2099 - Interface/Controls/Context Menu/csmnu.vb
@@ -1,6 +1,6 @@
 ﻿Imports System.Runtime.Versioning
 
-Public Class csmnu
+Public Class Csmnu
     Inherits System.Windows.Forms.ContextMenuStrip
 
     <SupportedOSPlatform("windows")>

--- a/Apps/Components/CMC/2099 - Interface/Controls/DataGridView/dgn.Designer.vb
+++ b/Apps/Components/CMC/2099 - Interface/Controls/DataGridView/dgn.Designer.vb
@@ -1,8 +1,8 @@
-﻿<Drawing.ToolboxBitmap(GetType(dgn), "dgn.ico")>
-Partial Class dgn
+﻿<Drawing.ToolboxBitmap(GetType(Dgn), "dgn.ico")>
+Partial Class Dgn
     Inherits System.Windows.Forms.DataGridView
 
-    <System.Diagnostics.DebuggerNonUserCode()> _
+    <System.Diagnostics.DebuggerNonUserCode()>
     Public Sub New(ByVal container As System.ComponentModel.IContainer)
         MyClass.New()
 
@@ -14,7 +14,7 @@ Partial Class dgn
     End Sub
 
     'Component overrides dispose to clean up the component list.
-    <System.Diagnostics.DebuggerNonUserCode()> _
+    <System.Diagnostics.DebuggerNonUserCode()>
     Protected Overrides Sub Dispose(ByVal disposing As Boolean)
         Try
             If disposing AndAlso components IsNot Nothing Then
@@ -31,7 +31,7 @@ Partial Class dgn
     'NOTE: The following procedure is required by the Component Designer
     'It can be modified using the Component Designer.
     'Do not modify it using the code editor.
-    <System.Diagnostics.DebuggerStepThrough()> _
+    <System.Diagnostics.DebuggerStepThrough()>
     Private Sub InitializeComponent()
         CType(Me, System.ComponentModel.ISupportInitialize).BeginInit()
         Me.SuspendLayout()
@@ -45,35 +45,12 @@ Partial Class dgn
         Me.ResumeLayout(False)
     End Sub
 
-    Private Sub dgn_EditingControlShowing(sender As Object, e As System.Windows.Forms.DataGridViewEditingControlShowingEventArgs) Handles Me.EditingControlShowing
-        'If DgnItem.CurrentCell.ColumnIndex = 9 Or DgnItem.CurrentCell.ColumnIndex = 10 Or DgnItem.CurrentCell.ColumnIndex = 11 Or DgnItem.CurrentCell.ColumnIndex = 12 And Not e.Control Is Nothing Then
-        '    Dim tb As TextBox = CType(e.Control, TextBox)
-        '    '---add an event handler to the TextBox control---
-        '    AddHandler tb.KeyPress, AddressOf DgnItem_KeyPress
-        'End If
-    End Sub
-
-    Private Sub dgn_KeyPress(sender As Object, e As System.Windows.Forms.KeyPressEventArgs) Handles Me.KeyPress
-        '        If (Not (Char.IsDigit(e.KeyChar) Or _
-        'Char.IsControl(e.KeyChar))) Then
-        '            e.Handled = True
-        '        End If
-    End Sub
-
     Private Sub dgn_RowPostPaint(sender As Object, e As System.Windows.Forms.DataGridViewRowPostPaintEventArgs) Handles Me.RowPostPaint
-        'If _varGunakanNomorBaris Then
         If Me.XOGunakanNomorBaris Then
-            ' get the row number in leading zero format, 
-            '  where the width of the number = the width of the maximum number
             Dim RowNumWidth As Integer = Me.RowCount.ToString().Length
             Dim RowNumber As String = RowNumWidth.ToString
-            'StringBuilder(RowNumber = New StringBuilder(RowNumWidth))
-            'RowNumber.Append(e.RowIndex + 1)
-            RowNumber &= e.RowIndex + 1
-            'While (RowNumber.Length < RowNumWidth)
-            '    RowNumber.Insert(0, "0")
-            'End While
 
+            RowNumber &= e.RowIndex + 1
 
             ' get the size of the row number string
             'SizeF(Sz = e.Graphics.MeasureString(RowNumber.ToString(), Me.Font))
@@ -83,8 +60,6 @@ Partial Class dgn
             If Me.RowHeadersWidth < (Sz.Width + 20) Then
                 Me.RowHeadersWidth = CType((Sz.Width + 20), Integer)
             End If
-            'If (Me.RowHeadersWidth < (Int())(Sz.Width + 20)) Then
-            '    Me.RowHeadersWidth = (Int())(Sz.Width + 20)
 
             ' draw the row number6
             e.Graphics.DrawString(CType(e.RowIndex + 1, String), Me.Font, System.Drawing.SystemBrushes.ControlText, e.RowBounds.Location.X + 15, e.RowBounds.Location.Y + ((e.RowBounds.Height - Sz.Height) / 2))
@@ -93,8 +68,6 @@ Partial Class dgn
         End If
 
         MyBase.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.DisableResizing
-        'MyBase.AlternatingRowsDefaultCellStyle.BackColor = System.Drawing.Color.FromArgb(192, 192, 255)
-        'MyBase.AlternatingRowsDefaultCellStyle.BackColor = CBS.WarnaAcakBaru(190, 255, 190, 255, 255, 255)
         MyBase.AllowUserToResizeRows = False
         MyBase.MultiSelect = False
         MyBase.SelectionMode = System.Windows.Forms.DataGridViewSelectionMode.FullRowSelect

--- a/Apps/Components/CMC/2099 - Interface/Controls/DataGridView/dgn.vb
+++ b/Apps/Components/CMC/2099 - Interface/Controls/DataGridView/dgn.vb
@@ -6,7 +6,7 @@
 ''' Datagridview dengan warna random dan nomor urut baris.
 ''' </summary>
 ''' <remarks></remarks>
-Public Class dgn
+Public Class Dgn
     Public Event XOSelected()
     'Public Event SLF_NewGridColor()
 
@@ -65,8 +65,6 @@ Public Class dgn
             If e.RowIndex > 0 And e.ColumnIndex = 0 Then
                 If MyBase.Item(0, e.RowIndex - 1).Value Is e.Value Then
                     e.Value = String.Empty
-                    'MyBase.AdvancedCellBorderStyle.Top = Windows.Forms.DataGridViewAdvancedCellBorderStyle.None
-                    'MyBase.Rows(e.RowIndex).DefaultCellStyle.BackColor = System.Drawing.Color.White
                 ElseIf e.RowIndex < MyBase.Rows.Count - 1 Then
 
                 End If

--- a/Apps/Components/CMC/2099 - Interface/Controls/DateTimePicker/dtp.Designer.vb
+++ b/Apps/Components/CMC/2099 - Interface/Controls/DateTimePicker/dtp.Designer.vb
@@ -1,8 +1,8 @@
-﻿<System.Drawing.ToolboxBitmap(GetType(CMCv.dtp), "dtp.ico")> _
-Partial Class dtp
+﻿<System.Drawing.ToolboxBitmap(GetType(CMCv.Dtp), "dtp.ico")>
+Partial Class Dtp
     Inherits System.Windows.Forms.DateTimePicker
 
-    <System.Diagnostics.DebuggerNonUserCode()> _
+    <System.Diagnostics.DebuggerNonUserCode()>
     Public Sub New(ByVal container As System.ComponentModel.IContainer)
         MyClass.New()
 
@@ -14,7 +14,7 @@ Partial Class dtp
     End Sub
 
     'Component overrides dispose to clean up the component list.
-    <System.Diagnostics.DebuggerNonUserCode()> _
+    <System.Diagnostics.DebuggerNonUserCode()>
     Protected Overrides Sub Dispose(ByVal disposing As Boolean)
         Try
             If disposing AndAlso components IsNot Nothing Then
@@ -31,7 +31,7 @@ Partial Class dtp
     'NOTE: The following procedure is required by the Component Designer
     'It can be modified using the Component Designer.
     'Do not modify it using the code editor.
-    <System.Diagnostics.DebuggerStepThrough()> _
+    <System.Diagnostics.DebuggerStepThrough()>
     Private Sub InitializeComponent()
         components = New System.ComponentModel.Container()
     End Sub

--- a/Apps/Components/CMC/2099 - Interface/Controls/DateTimePicker/dtp.vb
+++ b/Apps/Components/CMC/2099 - Interface/Controls/DateTimePicker/dtp.vb
@@ -1,7 +1,7 @@
 ﻿Imports System.ComponentModel
 Imports System.Runtime.Versioning
 
-Public Class dtp
+Public Class Dtp
     Inherits System.Windows.Forms.DateTimePicker
 
     <SupportedOSPlatform("windows")>

--- a/Apps/Components/CMC/2099 - Interface/Controls/GroupBox/gbx.Designer.vb
+++ b/Apps/Components/CMC/2099 - Interface/Controls/GroupBox/gbx.Designer.vb
@@ -1,8 +1,8 @@
-﻿<System.Drawing.ToolboxBitmap(GetType(CMCv.gbx), "gbx.ico")> _
-Partial Class gbx
+﻿<System.Drawing.ToolboxBitmap(GetType(CMCv.Gbx), "gbx.ico")>
+Partial Class Gbx
     Inherits System.Windows.Forms.GroupBox
 
-    <System.Diagnostics.DebuggerNonUserCode()> _
+    <System.Diagnostics.DebuggerNonUserCode()>
     Public Sub New(ByVal container As System.ComponentModel.IContainer)
         MyClass.New()
 
@@ -14,7 +14,7 @@ Partial Class gbx
     End Sub
 
     'Component overrides dispose to clean up the component list.
-    <System.Diagnostics.DebuggerNonUserCode()> _
+    <System.Diagnostics.DebuggerNonUserCode()>
     Protected Overrides Sub Dispose(ByVal disposing As Boolean)
         Try
             If disposing AndAlso components IsNot Nothing Then
@@ -31,7 +31,7 @@ Partial Class gbx
     'NOTE: The following procedure is required by the Component Designer
     'It can be modified using the Component Designer.
     'Do not modify it using the code editor.
-    <System.Diagnostics.DebuggerStepThrough()> _
+    <System.Diagnostics.DebuggerStepThrough()>
     Private Sub InitializeComponent()
         components = New System.ComponentModel.Container()
     End Sub

--- a/Apps/Components/CMC/2099 - Interface/Controls/GroupBox/gbx.vb
+++ b/Apps/Components/CMC/2099 - Interface/Controls/GroupBox/gbx.vb
@@ -1,6 +1,6 @@
 ﻿Imports System.Runtime.Versioning
 
-Public Class gbx
+Public Class Gbx
     Inherits System.Windows.Forms.GroupBox
 
     <SupportedOSPlatform("windows")>

--- a/Apps/Components/CMC/2099 - Interface/Controls/Label/lbl.Designer.vb
+++ b/Apps/Components/CMC/2099 - Interface/Controls/Label/lbl.Designer.vb
@@ -1,8 +1,8 @@
-﻿<System.Drawing.ToolboxBitmap(GetType(CMCv.lbl), "lbl.ico")> _
-Partial Class lbl
+﻿<System.Drawing.ToolboxBitmap(GetType(CMCv.Lbl), "lbl.ico")>
+Partial Class Lbl
     Inherits System.Windows.Forms.Label
 
-    <System.Diagnostics.DebuggerNonUserCode()> _
+    <System.Diagnostics.DebuggerNonUserCode()>
     Public Sub New(ByVal container As System.ComponentModel.IContainer)
         MyClass.New()
 
@@ -14,7 +14,7 @@ Partial Class lbl
     End Sub
 
     'Component overrides dispose to clean up the component list.
-    <System.Diagnostics.DebuggerNonUserCode()> _
+    <System.Diagnostics.DebuggerNonUserCode()>
     Protected Overrides Sub Dispose(ByVal disposing As Boolean)
         Try
             If disposing AndAlso components IsNot Nothing Then
@@ -31,7 +31,7 @@ Partial Class lbl
     'NOTE: The following procedure is required by the Component Designer
     'It can be modified using the Component Designer.
     'Do not modify it using the code editor.
-    <System.Diagnostics.DebuggerStepThrough()> _
+    <System.Diagnostics.DebuggerStepThrough()>
     Private Sub InitializeComponent()
         components = New System.ComponentModel.Container()
     End Sub

--- a/Apps/Components/CMC/2099 - Interface/Controls/Label/lbl.vb
+++ b/Apps/Components/CMC/2099 - Interface/Controls/Label/lbl.vb
@@ -1,6 +1,6 @@
 ﻿Imports System.Runtime.Versioning
 
-Public Class lbl
+Public Class Lbl
     Inherits System.Windows.Forms.Label
 
     <SupportedOSPlatform("windows")>
@@ -9,7 +9,6 @@ Public Class lbl
         Call ActivateLicenses()
         MyBase.Font = globalFontTxt
         Me.XOCustomElipsis = False
-        'Me.SLFTypeOfElipsis = TextFormatFlags.Default
         MyBase.DoubleBuffered = True
     End Sub
 

--- a/Apps/Components/CMC/2099 - Interface/Controls/LinkLabel/lnklbl.Designer.vb
+++ b/Apps/Components/CMC/2099 - Interface/Controls/LinkLabel/lnklbl.Designer.vb
@@ -1,8 +1,8 @@
-﻿<System.Drawing.ToolboxBitmap(GetType(CMCv.lnklbl), "lnklbl.ico")> _
-Partial Class lnklbl
+﻿<System.Drawing.ToolboxBitmap(GetType(CMCv.Lnklbl), "lnklbl.ico")>
+Partial Class Lnklbl
     Inherits System.Windows.Forms.LinkLabel
 
-    <System.Diagnostics.DebuggerNonUserCode()> _
+    <System.Diagnostics.DebuggerNonUserCode()>
     Public Sub New(ByVal container As System.ComponentModel.IContainer)
         MyClass.New()
 
@@ -14,7 +14,7 @@ Partial Class lnklbl
     End Sub
 
     'Component overrides dispose to clean up the component list.
-    <System.Diagnostics.DebuggerNonUserCode()> _
+    <System.Diagnostics.DebuggerNonUserCode()>
     Protected Overrides Sub Dispose(ByVal disposing As Boolean)
         Try
             If disposing AndAlso components IsNot Nothing Then
@@ -31,7 +31,7 @@ Partial Class lnklbl
     'NOTE: The following procedure is required by the Component Designer
     'It can be modified using the Component Designer.
     'Do not modify it using the code editor.
-    <System.Diagnostics.DebuggerStepThrough()> _
+    <System.Diagnostics.DebuggerStepThrough()>
     Private Sub InitializeComponent()
         components = New System.ComponentModel.Container()
     End Sub

--- a/Apps/Components/CMC/2099 - Interface/Controls/LinkLabel/lnklbl.vb
+++ b/Apps/Components/CMC/2099 - Interface/Controls/LinkLabel/lnklbl.vb
@@ -1,6 +1,6 @@
 ﻿Imports System.Runtime.Versioning
 
-Public Class lnklbl
+Public Class Lnklbl
     Inherits System.Windows.Forms.LinkLabel
 
     <SupportedOSPlatform("windows")>

--- a/Apps/Components/CMC/2099 - Interface/Controls/MaskEditBox/meb.Designer.vb
+++ b/Apps/Components/CMC/2099 - Interface/Controls/MaskEditBox/meb.Designer.vb
@@ -1,8 +1,8 @@
-﻿<System.Drawing.ToolboxBitmap(GetType(CMCv.meb), "meb.ico")> _
-Partial Class meb
+﻿<System.Drawing.ToolboxBitmap(GetType(CMCv.Meb), "meb.ico")>
+Partial Class Meb
     Inherits System.Windows.Forms.MaskedTextBox
 
-    <System.Diagnostics.DebuggerNonUserCode()> _
+    <System.Diagnostics.DebuggerNonUserCode()>
     Public Sub New(ByVal container As System.ComponentModel.IContainer)
         MyClass.New()
 
@@ -14,7 +14,7 @@ Partial Class meb
     End Sub
 
     'Component overrides dispose to clean up the component list.
-    <System.Diagnostics.DebuggerNonUserCode()> _
+    <System.Diagnostics.DebuggerNonUserCode()>
     Protected Overrides Sub Dispose(ByVal disposing As Boolean)
         Try
             If disposing AndAlso components IsNot Nothing Then
@@ -31,7 +31,7 @@ Partial Class meb
     'NOTE: The following procedure is required by the Component Designer
     'It can be modified using the Component Designer.
     'Do not modify it using the code editor.
-    <System.Diagnostics.DebuggerStepThrough()> _
+    <System.Diagnostics.DebuggerStepThrough()>
     Private Sub InitializeComponent()
         components = New System.ComponentModel.Container()
     End Sub

--- a/Apps/Components/CMC/2099 - Interface/Controls/MaskEditBox/meb.vb
+++ b/Apps/Components/CMC/2099 - Interface/Controls/MaskEditBox/meb.vb
@@ -1,6 +1,6 @@
 ﻿Imports System.Runtime.Versioning
 
-Public Class meb
+Public Class Meb
     Inherits System.Windows.Forms.MaskedTextBox
 
     <SupportedOSPlatform("windows")>

--- a/Apps/Components/CMC/2099 - Interface/Controls/Menu Strip/mnu.Designer.vb
+++ b/Apps/Components/CMC/2099 - Interface/Controls/Menu Strip/mnu.Designer.vb
@@ -1,8 +1,8 @@
-﻿<System.Drawing.ToolboxBitmap(GetType(CMCv.mnu), "mnu.ico")> _
-Partial Class mnu
+﻿<System.Drawing.ToolboxBitmap(GetType(CMCv.Mnu), "mnu.ico")>
+Partial Class Mnu
     Inherits System.Windows.Forms.MenuStrip
 
-    <System.Diagnostics.DebuggerNonUserCode()> _
+    <System.Diagnostics.DebuggerNonUserCode()>
     Public Sub New(ByVal container As System.ComponentModel.IContainer)
         MyClass.New()
 
@@ -14,7 +14,7 @@ Partial Class mnu
     End Sub
 
     'Component overrides dispose to clean up the component list.
-    <System.Diagnostics.DebuggerNonUserCode()> _
+    <System.Diagnostics.DebuggerNonUserCode()>
     Protected Overrides Sub Dispose(ByVal disposing As Boolean)
         Try
             If disposing AndAlso components IsNot Nothing Then
@@ -31,7 +31,7 @@ Partial Class mnu
     'NOTE: The following procedure is required by the Component Designer
     'It can be modified using the Component Designer.
     'Do not modify it using the code editor.
-    <System.Diagnostics.DebuggerStepThrough()> _
+    <System.Diagnostics.DebuggerStepThrough()>
     Private Sub InitializeComponent()
         components = New System.ComponentModel.Container()
     End Sub

--- a/Apps/Components/CMC/2099 - Interface/Controls/Menu Strip/mnu.vb
+++ b/Apps/Components/CMC/2099 - Interface/Controls/Menu Strip/mnu.vb
@@ -1,6 +1,6 @@
 ﻿Imports System.Runtime.Versioning
 
-Public Class mnu
+Public Class Mnu
     Inherits System.Windows.Forms.MenuStrip
 
     <SupportedOSPlatform("windows")>

--- a/Apps/Components/CMC/2099 - Interface/Controls/NumericUpDown/nud.Designer.vb
+++ b/Apps/Components/CMC/2099 - Interface/Controls/NumericUpDown/nud.Designer.vb
@@ -1,8 +1,8 @@
-﻿<System.Drawing.ToolboxBitmap(GetType(CMCv.nud), "nud.ico")> _
-Partial Class nud
+﻿<System.Drawing.ToolboxBitmap(GetType(CMCv.Nud), "nud.ico")>
+Partial Class Nud
     Inherits System.Windows.Forms.NumericUpDown
 
-    <System.Diagnostics.DebuggerNonUserCode()> _
+    <System.Diagnostics.DebuggerNonUserCode()>
     Public Sub New(ByVal container As System.ComponentModel.IContainer)
         MyClass.New()
 
@@ -14,7 +14,7 @@ Partial Class nud
     End Sub
 
     'Component overrides dispose to clean up the component list.
-    <System.Diagnostics.DebuggerNonUserCode()> _
+    <System.Diagnostics.DebuggerNonUserCode()>
     Protected Overrides Sub Dispose(ByVal disposing As Boolean)
         Try
             If disposing AndAlso components IsNot Nothing Then
@@ -31,7 +31,7 @@ Partial Class nud
     'NOTE: The following procedure is required by the Component Designer
     'It can be modified using the Component Designer.
     'Do not modify it using the code editor.
-    <System.Diagnostics.DebuggerStepThrough()> _
+    <System.Diagnostics.DebuggerStepThrough()>
     Private Sub InitializeComponent()
         components = New System.ComponentModel.Container()
     End Sub

--- a/Apps/Components/CMC/2099 - Interface/Controls/NumericUpDown/nud.vb
+++ b/Apps/Components/CMC/2099 - Interface/Controls/NumericUpDown/nud.vb
@@ -1,7 +1,7 @@
 ﻿Imports System.ComponentModel
 Imports System.Runtime.Versioning
 
-Public Class nud
+Public Class Nud
     Inherits System.Windows.Forms.NumericUpDown
 
     <SupportedOSPlatform("windows")>

--- a/Apps/Components/CMC/2099 - Interface/Controls/Panel/pnl.Designer.vb
+++ b/Apps/Components/CMC/2099 - Interface/Controls/Panel/pnl.Designer.vb
@@ -1,8 +1,8 @@
-﻿<System.Drawing.ToolboxBitmap(GetType(CMCv.pnl), "pnl.ico")> _
-Partial Class pnl
+﻿<System.Drawing.ToolboxBitmap(GetType(CMCv.Pnl), "pnl.ico")>
+Partial Class Pnl
     Inherits System.Windows.Forms.Panel
 
-    <System.Diagnostics.DebuggerNonUserCode()> _
+    <System.Diagnostics.DebuggerNonUserCode()>
     Public Sub New(ByVal container As System.ComponentModel.IContainer)
         MyClass.New()
 
@@ -14,7 +14,7 @@ Partial Class pnl
     End Sub
 
     'Component overrides dispose to clean up the component list.
-    <System.Diagnostics.DebuggerNonUserCode()> _
+    <System.Diagnostics.DebuggerNonUserCode()>
     Protected Overrides Sub Dispose(ByVal disposing As Boolean)
         Try
             If disposing AndAlso components IsNot Nothing Then
@@ -31,7 +31,7 @@ Partial Class pnl
     'NOTE: The following procedure is required by the Component Designer
     'It can be modified using the Component Designer.
     'Do not modify it using the code editor.
-    <System.Diagnostics.DebuggerStepThrough()> _
+    <System.Diagnostics.DebuggerStepThrough()>
     Private Sub InitializeComponent()
         components = New System.ComponentModel.Container()
     End Sub

--- a/Apps/Components/CMC/2099 - Interface/Controls/Panel/pnl.vb
+++ b/Apps/Components/CMC/2099 - Interface/Controls/Panel/pnl.vb
@@ -1,6 +1,6 @@
 ﻿Imports System.Runtime.Versioning
 
-Public Class pnl
+Public Class Pnl
     Inherits System.Windows.Forms.Panel
 
     <SupportedOSPlatform("windows")>

--- a/Apps/Components/CMC/2099 - Interface/Controls/PictureBox/pctbx.Designer.vb
+++ b/Apps/Components/CMC/2099 - Interface/Controls/PictureBox/pctbx.Designer.vb
@@ -1,8 +1,8 @@
-﻿<System.Drawing.ToolboxBitmap(GetType(CMCv.pctbx), "pctbx.ico")> _
-Partial Class pctbx
+﻿<System.Drawing.ToolboxBitmap(GetType(CMCv.Pctbx), "pctbx.ico")>
+Partial Class Pctbx
     Inherits System.Windows.Forms.PictureBox
 
-    <System.Diagnostics.DebuggerNonUserCode()> _
+    <System.Diagnostics.DebuggerNonUserCode()>
     Public Sub New(ByVal container As System.ComponentModel.IContainer)
         MyClass.New()
 
@@ -14,7 +14,7 @@ Partial Class pctbx
     End Sub
 
     'Component overrides dispose to clean up the component list.
-    <System.Diagnostics.DebuggerNonUserCode()> _
+    <System.Diagnostics.DebuggerNonUserCode()>
     Protected Overrides Sub Dispose(ByVal disposing As Boolean)
         Try
             If disposing AndAlso components IsNot Nothing Then
@@ -31,7 +31,7 @@ Partial Class pctbx
     'NOTE: The following procedure is required by the Component Designer
     'It can be modified using the Component Designer.
     'Do not modify it using the code editor.
-    <System.Diagnostics.DebuggerStepThrough()> _
+    <System.Diagnostics.DebuggerStepThrough()>
     Private Sub InitializeComponent()
         components = New System.ComponentModel.Container()
     End Sub

--- a/Apps/Components/CMC/2099 - Interface/Controls/PictureBox/pctbx.vb
+++ b/Apps/Components/CMC/2099 - Interface/Controls/PictureBox/pctbx.vb
@@ -2,7 +2,7 @@
 Imports System.Runtime.Versioning
 Imports System.Windows.Forms
 
-Public Class pctbx
+Public Class Pctbx
     Inherits System.Windows.Forms.PictureBox
     'Private initimg As New System.Drawing.Image
 

--- a/Apps/Components/CMC/2099 - Interface/Controls/ProgressBar/pgb.Designer.vb
+++ b/Apps/Components/CMC/2099 - Interface/Controls/ProgressBar/pgb.Designer.vb
@@ -1,8 +1,8 @@
-﻿<System.Drawing.ToolboxBitmap(GetType(CMCv.pgb), "pgb.ico")> _
-Partial Class pgb
+﻿<System.Drawing.ToolboxBitmap(GetType(CMCv.Pgb), "pgb.ico")>
+Partial Class Pgb
     Inherits System.Windows.Forms.ProgressBar
 
-    <System.Diagnostics.DebuggerNonUserCode()> _
+    <System.Diagnostics.DebuggerNonUserCode()>
     Public Sub New(ByVal container As System.ComponentModel.IContainer)
         MyClass.New()
 
@@ -14,7 +14,7 @@ Partial Class pgb
     End Sub
 
     'Component overrides dispose to clean up the component list.
-    <System.Diagnostics.DebuggerNonUserCode()> _
+    <System.Diagnostics.DebuggerNonUserCode()>
     Protected Overrides Sub Dispose(ByVal disposing As Boolean)
         Try
             If disposing AndAlso components IsNot Nothing Then
@@ -31,7 +31,7 @@ Partial Class pgb
     'NOTE: The following procedure is required by the Component Designer
     'It can be modified using the Component Designer.
     'Do not modify it using the code editor.
-    <System.Diagnostics.DebuggerStepThrough()> _
+    <System.Diagnostics.DebuggerStepThrough()>
     Private Sub InitializeComponent()
         components = New System.ComponentModel.Container()
     End Sub

--- a/Apps/Components/CMC/2099 - Interface/Controls/ProgressBar/pgb.vb
+++ b/Apps/Components/CMC/2099 - Interface/Controls/ProgressBar/pgb.vb
@@ -4,7 +4,7 @@ Imports System.Drawing.Drawing2D
 Imports System.Runtime.Versioning
 Imports System.Windows.Forms
 
-Public Class pgb
+Public Class Pgb
     Inherits System.Windows.Forms.ProgressBar
 
     <SupportedOSPlatform("windows")>

--- a/Apps/Components/CMC/2099 - Interface/Controls/RadioButton/rdo.Designer.vb
+++ b/Apps/Components/CMC/2099 - Interface/Controls/RadioButton/rdo.Designer.vb
@@ -1,8 +1,8 @@
-﻿<System.Drawing.ToolboxBitmap(GetType(CMCv.rdo), "rdo.ico")> _
-Partial Class rdo
+﻿<System.Drawing.ToolboxBitmap(GetType(CMCv.Rdo), "rdo.ico")>
+Partial Class Rdo
     Inherits System.Windows.Forms.RadioButton
 
-    <System.Diagnostics.DebuggerNonUserCode()> _
+    <System.Diagnostics.DebuggerNonUserCode()>
     Public Sub New(ByVal container As System.ComponentModel.IContainer)
         MyClass.New()
 
@@ -14,7 +14,7 @@ Partial Class rdo
     End Sub
 
     'Component overrides dispose to clean up the component list.
-    <System.Diagnostics.DebuggerNonUserCode()> _
+    <System.Diagnostics.DebuggerNonUserCode()>
     Protected Overrides Sub Dispose(ByVal disposing As Boolean)
         Try
             If disposing AndAlso components IsNot Nothing Then
@@ -31,7 +31,7 @@ Partial Class rdo
     'NOTE: The following procedure is required by the Component Designer
     'It can be modified using the Component Designer.
     'Do not modify it using the code editor.
-    <System.Diagnostics.DebuggerStepThrough()> _
+    <System.Diagnostics.DebuggerStepThrough()>
     Private Sub InitializeComponent()
         components = New System.ComponentModel.Container()
     End Sub

--- a/Apps/Components/CMC/2099 - Interface/Controls/RadioButton/rdo.vb
+++ b/Apps/Components/CMC/2099 - Interface/Controls/RadioButton/rdo.vb
@@ -1,6 +1,6 @@
 ﻿Imports System.Runtime.Versioning
 
-Public Class rdo
+Public Class Rdo
     Inherits System.Windows.Forms.RadioButton
 
     <SupportedOSPlatform("windows")>

--- a/Apps/Components/CMC/2099 - Interface/Controls/SplitContainer/spc.Designer.vb
+++ b/Apps/Components/CMC/2099 - Interface/Controls/SplitContainer/spc.Designer.vb
@@ -1,7 +1,7 @@
-﻿Partial Class spc
+﻿Partial Class Spc
     Inherits System.Windows.Forms.SplitContainer
 
-    <System.Diagnostics.DebuggerNonUserCode()> _
+    <System.Diagnostics.DebuggerNonUserCode()>
     Public Sub New(ByVal container As System.ComponentModel.IContainer)
         MyClass.New()
 
@@ -22,7 +22,7 @@
     'End Sub
 
     'Component overrides dispose to clean up the component list.
-    <System.Diagnostics.DebuggerNonUserCode()> _
+    <System.Diagnostics.DebuggerNonUserCode()>
     Protected Overrides Sub Dispose(ByVal disposing As Boolean)
         Try
             If disposing AndAlso components IsNot Nothing Then
@@ -39,7 +39,7 @@
     'NOTE: The following procedure is required by the Component Designer
     'It can be modified using the Component Designer.
     'Do not modify it using the code editor.
-    <System.Diagnostics.DebuggerStepThrough()> _
+    <System.Diagnostics.DebuggerStepThrough()>
     Private Sub InitializeComponent()
         components = New System.ComponentModel.Container()
     End Sub

--- a/Apps/Components/CMC/2099 - Interface/Controls/SplitContainer/spc.vb
+++ b/Apps/Components/CMC/2099 - Interface/Controls/SplitContainer/spc.vb
@@ -1,6 +1,6 @@
 ﻿Imports System.Runtime.Versioning
 
-Public Class spc
+Public Class Spc
     Inherits System.Windows.Forms.SplitContainer
 
     <SupportedOSPlatform("windows")>

--- a/Apps/Components/CMC/2099 - Interface/Controls/Status Strip/stt.Designer.vb
+++ b/Apps/Components/CMC/2099 - Interface/Controls/Status Strip/stt.Designer.vb
@@ -1,8 +1,8 @@
-﻿<System.Drawing.ToolboxBitmap(GetType(CMCv.stt), "stt.ico")> _
-Partial Class stt
+﻿<System.Drawing.ToolboxBitmap(GetType(CMCv.Stt), "stt.ico")>
+Partial Class Stt
     Inherits System.Windows.Forms.StatusStrip
 
-    <System.Diagnostics.DebuggerNonUserCode()> _
+    <System.Diagnostics.DebuggerNonUserCode()>
     Public Sub New(ByVal container As System.ComponentModel.IContainer)
         MyClass.New()
 
@@ -14,7 +14,7 @@ Partial Class stt
     End Sub
 
     'Component overrides dispose to clean up the component list.
-    <System.Diagnostics.DebuggerNonUserCode()> _
+    <System.Diagnostics.DebuggerNonUserCode()>
     Protected Overrides Sub Dispose(ByVal disposing As Boolean)
         Try
             If disposing AndAlso components IsNot Nothing Then
@@ -31,7 +31,7 @@ Partial Class stt
     'NOTE: The following procedure is required by the Component Designer
     'It can be modified using the Component Designer.
     'Do not modify it using the code editor.
-    <System.Diagnostics.DebuggerStepThrough()> _
+    <System.Diagnostics.DebuggerStepThrough()>
     Private Sub InitializeComponent()
         components = New System.ComponentModel.Container()
     End Sub

--- a/Apps/Components/CMC/2099 - Interface/Controls/Status Strip/stt.vb
+++ b/Apps/Components/CMC/2099 - Interface/Controls/Status Strip/stt.vb
@@ -1,6 +1,6 @@
 ﻿Imports System.Runtime.Versioning
 
-Public Class stt
+Public Class Stt
     Inherits System.Windows.Forms.StatusStrip
 
     <SupportedOSPlatform("windows")>

--- a/Apps/Components/CMC/2099 - Interface/Controls/TabControl/tbctl.Designer.vb
+++ b/Apps/Components/CMC/2099 - Interface/Controls/TabControl/tbctl.Designer.vb
@@ -1,7 +1,7 @@
-﻿Partial Class tbctl
+﻿Partial Class Tbctl
     Inherits System.Windows.Forms.TabControl
 
-    <System.Diagnostics.DebuggerNonUserCode()> _
+    <System.Diagnostics.DebuggerNonUserCode()>
     Public Sub New(ByVal container As System.ComponentModel.IContainer)
         MyClass.New()
 
@@ -13,7 +13,7 @@
     End Sub
 
     'Component overrides dispose to clean up the component list.
-    <System.Diagnostics.DebuggerNonUserCode()> _
+    <System.Diagnostics.DebuggerNonUserCode()>
     Protected Overrides Sub Dispose(ByVal disposing As Boolean)
         Try
             If disposing AndAlso components IsNot Nothing Then
@@ -30,7 +30,7 @@
     'NOTE: The following procedure is required by the Component Designer
     'It can be modified using the Component Designer.
     'Do not modify it using the code editor.
-    <System.Diagnostics.DebuggerStepThrough()> _
+    <System.Diagnostics.DebuggerStepThrough()>
     Private Sub InitializeComponent()
         components = New System.ComponentModel.Container()
     End Sub

--- a/Apps/Components/CMC/2099 - Interface/Controls/TabControl/tbctl.vb
+++ b/Apps/Components/CMC/2099 - Interface/Controls/TabControl/tbctl.vb
@@ -1,6 +1,6 @@
 ﻿Imports System.Runtime.Versioning
 
-Public Class tbctl
+Public Class Tbctl
     Inherits System.Windows.Forms.TabControl
 
     <SupportedOSPlatform("windows")>

--- a/Apps/Components/CMC/2099 - Interface/Controls/TextBox/txt.Designer.vb
+++ b/Apps/Components/CMC/2099 - Interface/Controls/TextBox/txt.Designer.vb
@@ -1,8 +1,8 @@
-﻿<System.Drawing.ToolboxBitmap(GetType(CMCv.txt), "txt.ico")> _
-Partial Class txt
+﻿<System.Drawing.ToolboxBitmap(GetType(CMCv.Txt), "txt.ico")>
+Partial Class Txt
     Inherits System.Windows.Forms.TextBox
 
-    <System.Diagnostics.DebuggerNonUserCode()> _
+    <System.Diagnostics.DebuggerNonUserCode()>
     Public Sub New(ByVal container As System.ComponentModel.IContainer)
         MyClass.New()
 
@@ -14,7 +14,7 @@ Partial Class txt
     End Sub
 
     'Component overrides dispose to clean up the component list.
-    <System.Diagnostics.DebuggerNonUserCode()> _
+    <System.Diagnostics.DebuggerNonUserCode()>
     Protected Overrides Sub Dispose(ByVal disposing As Boolean)
         Try
             If disposing AndAlso components IsNot Nothing Then
@@ -31,7 +31,7 @@ Partial Class txt
     'NOTE: The following procedure is required by the Component Designer
     'It can be modified using the Component Designer.
     'Do not modify it using the code editor.
-    <System.Diagnostics.DebuggerStepThrough()> _
+    <System.Diagnostics.DebuggerStepThrough()>
     Private Sub InitializeComponent()
         'components = New System.ComponentModel.Container()
         Me.SuspendLayout()

--- a/Apps/Components/CMC/2099 - Interface/Controls/TextBox/txt.vb
+++ b/Apps/Components/CMC/2099 - Interface/Controls/TextBox/txt.vb
@@ -11,7 +11,7 @@ Imports System.Text.RegularExpressions
 ''' Custom komponen textbox. Dilengkapi dengan sekuensial validasi pada button clicked.
 ''' </summary>
 ''' <remarks></remarks>
-Public Class txt
+Public Class Txt
     Inherits System.Windows.Forms.TextBox
 
     <SupportedOSPlatform("windows")>

--- a/Apps/Components/CMC/2099 - Interface/Controls/TreeView/tv.Designer.vb
+++ b/Apps/Components/CMC/2099 - Interface/Controls/TreeView/tv.Designer.vb
@@ -1,7 +1,7 @@
-﻿Partial Class tv
+﻿Partial Class Tv
     Inherits System.Windows.Forms.TreeView
 
-    <System.Diagnostics.DebuggerNonUserCode()> _
+    <System.Diagnostics.DebuggerNonUserCode()>
     Public Sub New(ByVal container As System.ComponentModel.IContainer)
         MyClass.New()
 
@@ -22,7 +22,7 @@
     'End Sub
 
     'Component overrides dispose to clean up the component list.
-    <System.Diagnostics.DebuggerNonUserCode()> _
+    <System.Diagnostics.DebuggerNonUserCode()>
     Protected Overrides Sub Dispose(ByVal disposing As Boolean)
         Try
             If disposing AndAlso components IsNot Nothing Then
@@ -39,7 +39,7 @@
     'NOTE: The following procedure is required by the Component Designer
     'It can be modified using the Component Designer.
     'Do not modify it using the code editor.
-    <System.Diagnostics.DebuggerStepThrough()> _
+    <System.Diagnostics.DebuggerStepThrough()>
     Private Sub InitializeComponent()
         components = New System.ComponentModel.Container()
     End Sub

--- a/Apps/Components/CMC/2099 - Interface/Controls/TreeView/tv.vb
+++ b/Apps/Components/CMC/2099 - Interface/Controls/TreeView/tv.vb
@@ -2,7 +2,7 @@
 
 Imports System.Runtime.Versioning
 
-Public Class tv
+Public Class Tv
     Inherits System.Windows.Forms.TreeView
 
     <SupportedOSPlatform("windows")>

--- a/Apps/Components/CMC/CMCv.vbproj
+++ b/Apps/Components/CMC/CMCv.vbproj
@@ -108,129 +108,127 @@
       <DependentUpon>PHTRZ.vb</DependentUpon>
     </Compile>
     <Compile Update="2099 - Interface\Controls\Button\btn.Designer.vb">
-      <DependentUpon>btn.vb</DependentUpon>
+      <DependentUpon>Btn.vb</DependentUpon>
     </Compile>
-    <Compile Update="2099 - Interface\Controls\Button\btn.vb">
+    <Compile Update="2099 - Interface\Controls\Button\Btn.vb">
       <SubType>Component</SubType>
     </Compile>
     <Compile Update="2099 - Interface\Controls\CheckBox\chk.Designer.vb">
-      <DependentUpon>chk.vb</DependentUpon>
+      <DependentUpon>Chk.vb</DependentUpon>
     </Compile>
-    <Compile Update="2099 - Interface\Controls\CheckBox\chk.vb">
+    <Compile Update="2099 - Interface\Controls\CheckBox\Chk.vb">
       <SubType>Component</SubType>
     </Compile>
     <Compile Update="2099 - Interface\Controls\ComboBox\cbo.Designer.vb">
-      <DependentUpon>cbo.vb</DependentUpon>
+      <DependentUpon>Cbo.vb</DependentUpon>
     </Compile>
-    <Compile Update="2099 - Interface\Controls\ComboBox\cbo.vb">
+    <Compile Update="2099 - Interface\Controls\ComboBox\Cbo.vb">
       <SubType>Component</SubType>
     </Compile>
     <Compile Update="2099 - Interface\Controls\Context Menu\csmnu.Designer.vb">
-      <DependentUpon>csmnu.vb</DependentUpon>
+      <DependentUpon>Csmnu.vb</DependentUpon>
     </Compile>
-    <Compile Update="2099 - Interface\Controls\Context Menu\csmnu.vb">
+    <Compile Update="2099 - Interface\Controls\Context Menu\Csmnu.vb">
       <SubType>Component</SubType>
     </Compile>
     <Compile Update="2099 - Interface\Controls\DataGridView\dgn.Designer.vb">
-      <DependentUpon>dgn.vb</DependentUpon>
+      <DependentUpon>Dgn.vb</DependentUpon>
     </Compile>
-    <Compile Update="2099 - Interface\Controls\DataGridView\dgn.vb">
-      <SubType>Component</SubType>
-    </Compile>
+    <Compile Update="2099 - Interface\Controls\DataGridView\Dgn.vb" />
     <Compile Update="2099 - Interface\Controls\DateTimePicker\dtp.Designer.vb">
-      <DependentUpon>dtp.vb</DependentUpon>
+      <DependentUpon>Dtp.vb</DependentUpon>
     </Compile>
-    <Compile Update="2099 - Interface\Controls\DateTimePicker\dtp.vb">
+    <Compile Update="2099 - Interface\Controls\DateTimePicker\Dtp.vb">
       <SubType>Component</SubType>
     </Compile>
     <Compile Update="2099 - Interface\Controls\GroupBox\gbx.Designer.vb">
-      <DependentUpon>gbx.vb</DependentUpon>
+      <DependentUpon>Gbx.vb</DependentUpon>
     </Compile>
-    <Compile Update="2099 - Interface\Controls\GroupBox\gbx.vb">
+    <Compile Update="2099 - Interface\Controls\GroupBox\Gbx.vb">
       <SubType>Component</SubType>
     </Compile>
     <Compile Update="2099 - Interface\Controls\Label\lbl.Designer.vb">
-      <DependentUpon>lbl.vb</DependentUpon>
+      <DependentUpon>Lbl.vb</DependentUpon>
     </Compile>
-    <Compile Update="2099 - Interface\Controls\Label\lbl.vb">
+    <Compile Update="2099 - Interface\Controls\Label\Lbl.vb">
       <SubType>Component</SubType>
     </Compile>
     <Compile Update="2099 - Interface\Controls\LinkLabel\lnklbl.Designer.vb">
-      <DependentUpon>lnklbl.vb</DependentUpon>
+      <DependentUpon>Lnklbl.vb</DependentUpon>
     </Compile>
-    <Compile Update="2099 - Interface\Controls\LinkLabel\lnklbl.vb">
+    <Compile Update="2099 - Interface\Controls\LinkLabel\Lnklbl.vb">
       <SubType>Component</SubType>
     </Compile>
     <Compile Update="2099 - Interface\Controls\MaskEditBox\meb.Designer.vb">
-      <DependentUpon>meb.vb</DependentUpon>
+      <DependentUpon>Meb.vb</DependentUpon>
     </Compile>
-    <Compile Update="2099 - Interface\Controls\MaskEditBox\meb.vb">
+    <Compile Update="2099 - Interface\Controls\MaskEditBox\Meb.vb">
       <SubType>Component</SubType>
     </Compile>
     <Compile Update="2099 - Interface\Controls\Menu Strip\mnu.Designer.vb">
-      <DependentUpon>mnu.vb</DependentUpon>
+      <DependentUpon>Mnu.vb</DependentUpon>
     </Compile>
-    <Compile Update="2099 - Interface\Controls\Menu Strip\mnu.vb">
+    <Compile Update="2099 - Interface\Controls\Menu Strip\Mnu.vb">
       <SubType>Component</SubType>
     </Compile>
     <Compile Update="2099 - Interface\Controls\NumericUpDown\nud.Designer.vb">
-      <DependentUpon>nud.vb</DependentUpon>
+      <DependentUpon>Nud.vb</DependentUpon>
     </Compile>
-    <Compile Update="2099 - Interface\Controls\NumericUpDown\nud.vb">
+    <Compile Update="2099 - Interface\Controls\NumericUpDown\Nud.vb">
       <SubType>Component</SubType>
     </Compile>
     <Compile Update="2099 - Interface\Controls\Panel\pnl.Designer.vb">
-      <DependentUpon>pnl.vb</DependentUpon>
+      <DependentUpon>Pnl.vb</DependentUpon>
     </Compile>
-    <Compile Update="2099 - Interface\Controls\Panel\pnl.vb">
+    <Compile Update="2099 - Interface\Controls\Panel\Pnl.vb">
       <SubType>Component</SubType>
     </Compile>
     <Compile Update="2099 - Interface\Controls\PictureBox\pctbx.Designer.vb">
-      <DependentUpon>pctbx.vb</DependentUpon>
+      <DependentUpon>Pctbx.vb</DependentUpon>
     </Compile>
-    <Compile Update="2099 - Interface\Controls\PictureBox\pctbx.vb">
+    <Compile Update="2099 - Interface\Controls\PictureBox\Pctbx.vb">
       <SubType>Component</SubType>
     </Compile>
     <Compile Update="2099 - Interface\Controls\ProgressBar\pgb.Designer.vb">
-      <DependentUpon>pgb.vb</DependentUpon>
+      <DependentUpon>Pgb.vb</DependentUpon>
     </Compile>
-    <Compile Update="2099 - Interface\Controls\ProgressBar\pgb.vb">
+    <Compile Update="2099 - Interface\Controls\ProgressBar\Pgb.vb">
       <SubType>Component</SubType>
     </Compile>
     <Compile Update="2099 - Interface\Controls\RadioButton\rdo.Designer.vb">
-      <DependentUpon>rdo.vb</DependentUpon>
+      <DependentUpon>Rdo.vb</DependentUpon>
     </Compile>
-    <Compile Update="2099 - Interface\Controls\RadioButton\rdo.vb">
+    <Compile Update="2099 - Interface\Controls\RadioButton\Rdo.vb">
       <SubType>Component</SubType>
     </Compile>
     <Compile Update="2099 - Interface\Controls\SplitContainer\spc.Designer.vb">
-      <DependentUpon>spc.vb</DependentUpon>
+      <DependentUpon>Spc.vb</DependentUpon>
     </Compile>
-    <Compile Update="2099 - Interface\Controls\SplitContainer\spc.vb">
+    <Compile Update="2099 - Interface\Controls\SplitContainer\Spc.vb">
       <SubType>Component</SubType>
     </Compile>
     <Compile Update="2099 - Interface\Controls\Status Strip\stt.Designer.vb">
-      <DependentUpon>stt.vb</DependentUpon>
+      <DependentUpon>Stt.vb</DependentUpon>
     </Compile>
-    <Compile Update="2099 - Interface\Controls\Status Strip\stt.vb">
+    <Compile Update="2099 - Interface\Controls\Status Strip\Stt.vb">
       <SubType>Component</SubType>
     </Compile>
     <Compile Update="2099 - Interface\Controls\TabControl\tbctl.Designer.vb">
-      <DependentUpon>tbctl.vb</DependentUpon>
+      <DependentUpon>Tbctl.vb</DependentUpon>
     </Compile>
-    <Compile Update="2099 - Interface\Controls\TabControl\tbctl.vb">
+    <Compile Update="2099 - Interface\Controls\TabControl\Tbctl.vb">
       <SubType>Component</SubType>
     </Compile>
     <Compile Update="2099 - Interface\Controls\TextBox\txt.Designer.vb">
-      <DependentUpon>txt.vb</DependentUpon>
+      <DependentUpon>Txt.vb</DependentUpon>
     </Compile>
-    <Compile Update="2099 - Interface\Controls\TextBox\txt.vb">
+    <Compile Update="2099 - Interface\Controls\TextBox\Txt.vb">
       <SubType>Component</SubType>
     </Compile>
     <Compile Update="2099 - Interface\Controls\TreeView\tv.Designer.vb">
-      <DependentUpon>tv.vb</DependentUpon>
+      <DependentUpon>Tv.vb</DependentUpon>
     </Compile>
-    <Compile Update="2099 - Interface\Controls\TreeView\tv.vb">
+    <Compile Update="2099 - Interface\Controls\TreeView\Tv.vb">
       <SubType>Component</SubType>
     </Compile>
     <Compile Update="2099 - Interface\Forms\Templates\Windows7\Blank.Designer.vb">


### PR DESCRIPTION
Renaming components

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Standardized the naming conventions for various controls by updating class names to follow consistent casing (e.g., `btn` to `Btn`, `chk` to `Chk`).
  - Adjusted attribute references and method signatures to align with the new naming conventions.
  
- **Chores**
  - Updated project file to reflect new capitalization in file references for controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->