### PR TITLE
add connection test button for mysql

### DIFF
--- a/Apps/Components/Connect/020. Module/Global.vb
+++ b/Apps/Components/Connect/020. Module/Global.vb
@@ -20,7 +20,7 @@ Module [Global]
     Public WithEvents ERC As New CMCv.UI.Canvas.FRMerrorreporting
     Public ErrorCatcher As New Ladybug.Log.Fields
 
-    Public varProperties As New LibApp.Ingrid.Global.Properties
+    Public varDataProperties As New LibApp.Ingrid.Global.Properties
 
 #Region "Custom Message Box"
     ''' <summary>

--- a/Apps/Components/Connect/030. Form/020. Commands/001. Connection/FRMconn.vb
+++ b/Apps/Components/Connect/030. Form/020. Commands/001. Connection/FRMconn.vb
@@ -50,10 +50,10 @@ Namespace UI.Canvas
         ''' </summary>
         <SupportedOSPlatform("windows")>
         Private Sub GetRowID()
-            varProperties.ConnectionId = "-1"
+            varDataProperties.ConnectionId = "-1"
 
             If DgnConnection.RowCount > 0 Then
-                varProperties.ConnectionId = DgnConnection.CurrentRow.Cells("ID").Value.ToString
+                varDataProperties.ConnectionId = DgnConnection.CurrentRow.Cells("ID").Value.ToString
             End If
         End Sub
 #End Region
@@ -95,8 +95,8 @@ Namespace UI.Canvas
         ''' </summary>
         <SupportedOSPlatform("windows")>
         Private Sub EventDataAddNew() Handles COMmainframemenu.EventDataAddNew
-            varProperties.ConnectionIsNew = True
-            varProperties.ConnectionId = "-1"
+            varDataProperties.ConnectionIsNew = True
+            varDataProperties.ConnectionId = "-1"
             FRMconn_editor = New FRMconnEditor
             Display(FRMconn_editor, UI.Resource.ImageLibrary.EDIT_ICON, My.Application.Info.AssemblyName, "Add New Record", "Add new connection", True)
             SLFStatus.Text = String.Empty
@@ -108,9 +108,9 @@ Namespace UI.Canvas
         <SupportedOSPlatform("windows")>
         Public Sub EventDataEdit() Handles COMmainframemenu.EventDataEdit
             Call GetRowID()
-            varProperties.ConnectionIsNew = False
+            varDataProperties.ConnectionIsNew = False
 
-            If varProperties.ConnectionId Is "-1" Then
+            If varDataProperties.ConnectionId Is "-1" Then
                 Decision(My.Application.Info.AssemblyName, "No record selected", LibApp.Ingrid.Global.PopupType.Error, "", CMCv.UI.Canvas.FRMdialogbox.MessageIcon.Error, CMCv.UI.Canvas.FRMdialogbox.MessageTypes.OkOnly)
             Else
                 FRMconn_editor = New FRMconnEditor
@@ -125,10 +125,10 @@ Namespace UI.Canvas
         <SupportedOSPlatform("windows")>
         Private Sub EventDataDelete() Handles COMmainframemenu.EventDataDelete
             Call GetRowID()
-            If varProperties.ConnectionId Is "-1" Then
+            If varDataProperties.ConnectionId Is "-1" Then
                 Decision(My.Application.Info.AssemblyName, "No record selected", LibApp.Ingrid.Global.PopupType.Error, "", CMCv.UI.Canvas.FRMdialogbox.MessageIcon.Error, CMCv.UI.Canvas.FRMdialogbox.MessageTypes.OkOnly)
             Else
-                varProperties.ConnectionIsNew = False
+                varDataProperties.ConnectionIsNew = False
 
                 With DgnConnection.CurrentRow
                     Dim varMessage As New StringBuilder()
@@ -146,7 +146,7 @@ Namespace UI.Canvas
                     varMessage.AppendLine(varLine)
 
                     If Decision(My.Application.Info.AssemblyName, Convert.ToString(varMessage), LibApp.Ingrid.Global.PopupType.Delete, "", CMCv.UI.Canvas.FRMdialogbox.MessageIcon.Question, CMCv.UI.Canvas.FRMdialogbox.MessageTypes.YesNo) = System.Windows.Forms.DialogResult.Yes Then
-                        If (CMDconn.View.DeleteData(Convert.ToString(varProperties.ConnectionId))) Then
+                        If (CMDconn.View.DeleteData(Convert.ToString(varDataProperties.ConnectionId))) Then
                             Call GetData(True)
                             SLFStatus.Text = "Success"
                         Else
@@ -210,8 +210,5 @@ Namespace UI.Canvas
             Me.Close()
         End Sub
 
-        Private Sub FRMconn_Closing(sender As Object, e As CancelEventArgs) Handles Me.Closing
-
-        End Sub
     End Class
 End Namespace

--- a/Apps/Components/Connect/030. Form/020. Commands/001. Connection/FRMconnEditor.vb
+++ b/Apps/Components/Connect/030. Form/020. Commands/001. Connection/FRMconnEditor.vb
@@ -27,9 +27,9 @@ Namespace UI.Canvas
         <SupportedOSPlatform("windows")>
         Private Sub LoadData()
             Try
-                CMDconn.Editor.GetRowValue(varProperties)
+                CMDconn.Editor.GetRowValue(varDataProperties)
 
-                With varProperties
+                With varDataProperties
                     If (.ConnectionIsMasked) Then
                         TxtAddress.UseSystemPasswordChar = True
                         TxtPort.UseSystemPasswordChar = True
@@ -120,7 +120,7 @@ Namespace UI.Canvas
                 Return
             End If
 
-            With varProperties
+            With varDataProperties
                 .ConnectionName = TxtConnectionName.Text.Trim
                 .ConnectionDatabaseEngine = CboDBEngine.Text
                 .ConnectionServerAddress = TxtAddress.Text.Trim
@@ -130,13 +130,12 @@ Namespace UI.Canvas
                 .ConnectionDatabaseName = TxtDatabaseName.Text.Trim
                 .ConnectionIsDefault = ChkDefault.Checked
                 .ConnectionIsMasked = ChkIsMasked.Checked
-                .ConnectionIsNew = varProperties.ConnectionIsNew
                 .ConnectionIsPasswordChanged = varIsPasswordChange
                 .ConnectionClientCode = TxtClient.Text.Trim
-                .ConnectionId = Convert.ToString(varProperties.ConnectionId)
+                .ConnectionId = Convert.ToString(varDataProperties.ConnectionId)
             End With
 
-            If (CMDconn.Editor.PushData(varProperties)) Then
+            If (CMDconn.Editor.PushData(varDataProperties)) Then
                 SLFStatus.Text = "Success"
                 RaiseEvent EventRecordSaved()
                 Me.Close()
@@ -196,8 +195,8 @@ Namespace UI.Canvas
 
             CboDBEngine.DataSource = [Enum].GetValues(GetType(LibApp.Ingrid.Global.DatabaseEngine))
 
-            If (varProperties.ConnectionIsNew) Then
-                varProperties.ConnectionId = CMCv.Security.Encrypt.MD5()
+            If (varDataProperties.ConnectionIsNew) Then
+                varDataProperties.ConnectionId = CMCv.Security.Encrypt.MD5()
                 ChkIsMasked.Visible = True
             Else
                 ChkIsMasked.Visible = False
@@ -235,7 +234,7 @@ Namespace UI.Canvas
         <SupportedOSPlatform("windows")>
         Private Sub ComponentMainframeMenu_EventFileUndoAll() Handles ComponentMainframeMenu.EventFileUndoAll
             If Decision(My.Application.Info.AssemblyName, "Do you want to undo all changes?", LibApp.Ingrid.Global.PopupType.Question, "", CMCv.UI.Canvas.FRMdialogbox.MessageIcon.Question, CMCv.UI.Canvas.FRMdialogbox.MessageTypes.YesNo) = DialogResult.Yes Then
-                If (varProperties.ConnectionIsNew) Then
+                If (varDataProperties.ConnectionIsNew) Then
                     TxtConnectionName.Clear()
                     TxtAddress.Clear()
                     TxtPort.Clear()
@@ -359,6 +358,23 @@ Namespace UI.Canvas
                 TxtPort.UseSystemPasswordChar = False
                 TxtUsername.UseSystemPasswordChar = False
                 TxtDatabaseName.UseSystemPasswordChar = False
+            End If
+        End Sub
+
+        <SupportedOSPlatform("windows")>
+        Private Sub BtnTest_Click(sender As Object, e As EventArgs) Handles Btn_Test.Click
+            If CboDBEngine.Text = "MYSQL" Then
+                Try
+                    Dim varMysql As New CMCv.Database.Connect.Mysqlconnection
+                    Dim varConnection As MySql.Data.MySqlClient.MySqlConnection
+                    varConnection = New MySql.Data.MySqlClient.MySqlConnection(varMysql.Mysqlforcessl(TxtAddress.XOSqlText, CInt(TxtPort.XOSqlText), TxtDatabaseName.XOSqlText, TxtUsername.XOSqlText, TxtPassword.XOSqlText))
+                    varConnection.Open()
+                    MessageBox.Show("Connection test successful.")
+                    varConnection.Close()
+                    varConnection.Dispose()
+                Catch ex As Exception
+                    MessageBox.Show("Connection test failed: " & ex.Message)
+                End Try
             End If
         End Sub
 #End Region

--- a/Apps/Components/Ingrid-Launcher/030. Form/000. Launcher/FRMapplauncher.vb
+++ b/Apps/Components/Ingrid-Launcher/030. Form/000. Launcher/FRMapplauncher.vb
@@ -159,7 +159,7 @@ Namespace UI
             Using client As New HttpClient()
                 Try
                     varCloudstorageUrl = My.Settings.CloudstorageUrl
-                    Dim url As String = varCloudstorageUrl & "files/catalog.db"
+                    Dim url As String = varCloudstorageUrl & "conf/catalog.db"
                     Dim savePath As String = IO.Path.Combine(
                     Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData) & "\ardhagp\Ingrid .NET\Resources",
                     "catalog.db"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a connection test option for MySQL databases, with success and error notifications.
  * Improved handling when adding, editing, and deleting connection records.

* **Bug Fixes**
  * Fixed connection selection and record identification during connection management.
  * Updated catalog downloads to retrieve the catalog from the correct location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->